### PR TITLE
displaying block trans time

### DIFF
--- a/src/app/components/block/block.component.html
+++ b/src/app/components/block/block.component.html
@@ -92,7 +92,7 @@
 								<tr>
 									<th>#</th>
 									<th>{{ 'BlockId' | translate }}</th>
-									<th>{{ 'CreatedAt' | translate }}</th>
+									<th>{{ 'Timestamp' | translate }}</th>
 									<th>{{ 'Messages' | translate }}</th>
 								</tr>
 								</thead>
@@ -100,7 +100,7 @@
 								<tr *ngFor="let transaction of transactions">
 									<td><a routerLink="/transactions/{{transaction.transaction_id}}">{{transaction.transaction_id|slice:0:32}}...</a></td>
 									<td><a routerLink="/search" [queryParams]="{q: transaction.block_id}">{{transaction.block_id |slice:0:32}}...</a></td>
-									<td>{{transaction.createdAt.sec * 1000 | date:'medium'}}</td>
+									<td>{{transaction.ref_block_timestamp.sec * 1000 | date:'medium'}}</td>
 									<td>{{transaction.messages.length}}</td>
 								</tr>
 								</tbody>

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -169,7 +169,7 @@
 								<tr *ngFor="let transaction of transactions">
 									<td><a routerLink="/transactions/{{transaction.transaction_id}}">{{transaction.transaction_id | slice:0:32}}...</a>
 									</td>
-									<td>{{transaction.createdAt.sec * 1000 | date:'medium'}}</td>
+									<td>{{transaction.ref_block_timestamp.sec * 1000 | date:'medium'}}</td>
 									<td>{{transaction.messages.length}}</td>
 								</tr>
 								</tbody>

--- a/src/app/components/transaction/transaction.component.html
+++ b/src/app/components/transaction/transaction.component.html
@@ -28,8 +28,8 @@
 									</td>
 								</tr>
 								<tr>
-									<td>{{ 'CreatedAt' | translate }}:</td>
-									<td>{{transaction.createdAt.sec * 1000 | date:'medium'}}</td>
+									<td>{{ 'Timestamp' | translate }}:</td>
+									<td>{{transaction.ref_block_timestamp.sec * 1000 | date:'medium'}}</td>
 								</tr>
 								<tr>
 									<td>{{ 'Scope' | translate }}:</td>

--- a/src/app/components/transactions/transactions.component.html
+++ b/src/app/components/transactions/transactions.component.html
@@ -27,16 +27,16 @@
 								<thead>
 								<tr>
 									<th>#</th>
-									<th>{{ 'BlockId' | translate }}</th>
-									<th>{{ 'CreatedAt' | translate }}</th>
+									<th>{{ 'Block' | translate }}</th>
+									<th>{{ 'Timestamp' | translate }}</th>
 									<th>{{ 'Messages' | translate }}</th>
 								</tr>
 								</thead>
 								<tbody>
 								<tr *ngFor="let transaction of transactions">
 									<td><a routerLink="/transactions/{{transaction.transaction_id}}">{{transaction.transaction_id|slice:0:32}}...</a></td>
-									<td><a routerLink="/search" [queryParams]="{q: transaction.block_id}">{{transaction.block_id |slice:0:32}}...</a></td>
-									<td>{{transaction.createdAt.sec * 1000 | date:'medium'}}</td>
+									<td><a routerLink="/search" [queryParams]="{q: transaction.block_id}">{{transaction.ref_block_num}}</a></td>
+									<td>{{transaction.ref_block_timestamp.sec * 1000 | date:'medium'}}</td>
 									<td>{{transaction.messages.length}}</td>
 								</tr>
 								</tbody>


### PR DESCRIPTION
This change will display the transaction time from the block document instead of the createdAt time of the transaction.  

Please note.  This PR is submitted in conjunction with https://github.com/EOSEssentials/EOSTracker-API/pull/13.  Please see the note about data inconsistencies on that PR.