### PR TITLE
refactor account component to use services

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import {Ng2Webstorage} from 'ngx-webstorage';
 import { SettingsComponent } from './components/settings/settings.component';
 import {ProducerComponent} from './components/producer/producer.component';
 import {ToKbPipes} from './pipes/tokb.pipes';
+import {CmcService} from './services/cmc.service';
 
 export function HttpLoaderFactory(http: HttpClient) {
   return new TranslateHttpLoader(http);
@@ -99,6 +100,7 @@ const appRoutes: Routes = [
     EosService,
     AccountService,
     ProducerService,
+    CmcService,
     {provide: JsonPipe, useClass: SafeJsonPipe}
   ],
   bootstrap: [AppComponent]

--- a/src/app/components/account/account.component.ts
+++ b/src/app/components/account/account.component.ts
@@ -1,8 +1,8 @@
 import {Component, OnInit} from '@angular/core';
-import {HttpClient} from '@angular/common/http';
 import {ActivatedRoute, Router} from '@angular/router';
-import {environment} from '../../../environments/environment';
 import {Subscription} from 'rxjs/Subscription';
+import {AccountService} from '../../services/account.service';
+import {CmcService} from '../../services/cmc.service';
 import {EosService} from '../../services/eos.service';
 
 @Component({
@@ -12,7 +12,7 @@ import {EosService} from '../../services/eos.service';
 })
 export class AccountComponent implements OnInit {
 
-  public name: number;
+  public name: string;
   public tables = null;
   public account = null;
   public accountRaw = null;
@@ -23,8 +23,13 @@ export class AccountComponent implements OnInit {
   private subscriber: Subscription;
   page = 1;
 
-  constructor(private route: ActivatedRoute, private http: HttpClient, private router: Router, private eosService: EosService) {
-  }
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router, 
+    private eosService: EosService,
+    private accountService: AccountService,
+    private cmcService: CmcService
+  ) { }
 
   ngOnInit() {
 
@@ -36,7 +41,7 @@ export class AccountComponent implements OnInit {
       this.tables = null;
       this.name = params['id'];
 
-      this.http.get(environment.apiUrl + '/accounts/' + this.name).subscribe(data => {
+      this.accountService.getAccount(this.name).subscribe(data => {
         this.account = data;
         if (this.account.abi && this.account.abi.tables) {
           this.tables = this.account.abi.tables;
@@ -75,7 +80,7 @@ export class AccountComponent implements OnInit {
         }
       });
 
-      this.http.get('https://api.coinmarketcap.com/v2/ticker/1765/').subscribe(result => {
+      this.cmcService.getEOSTicker().subscribe(result => {
         if (result['data']) {
           this.eosPrice = result['data'].quotes.USD.price;
         }
@@ -84,7 +89,7 @@ export class AccountComponent implements OnInit {
       this.subscriber = this.route.queryParams.subscribe(params => {
         this.page = params['page'] || 1;
 
-        this.http.get(environment.apiUrl + '/accounts/' + this.name + '/actions?page=' + this.page).subscribe(data => {
+        this.accountService.getAccountActions(this.name, this.page).subscribe(data => {
           data = (data[0]) ? data : [];
           this.actions = data;
         });

--- a/src/app/models/Action.ts
+++ b/src/app/models/Action.ts
@@ -1,0 +1,10 @@
+export interface Action {
+  account: string;
+  authorizations?: any[];
+  blockId: number;
+  createdAt: number;
+  data?: any;
+  id: string;
+  name: string;
+  transaction: string;
+}

--- a/src/app/services/account.service.ts
+++ b/src/app/services/account.service.ts
@@ -1,16 +1,31 @@
-import {Injectable} from '@angular/core';
-import {Account} from '../models/Account';
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import { Account } from '../models/Account';
+import { Action } from '../models/Action';
 
 @Injectable()
 export class AccountService {
-  items: Account[] = [];
 
-  constructor() {
-    //this.items = data.items;
+  constructor(
+    private http: HttpClient
+  ) { }
 
+  getAccount(name: string): Observable<Account> {
+    return this.http.get(`${environment.apiUrl}/accounts/${name}`).pipe(
+      map(account => account as Account)
+    );
   }
 
-  get (id: number) {
-    return this.items[id];
+  getAccountActions(name: string, page = 1): Observable<Action[]> {
+    return this.http.get(`${environment.apiUrl}/accounts/${name}/actions`, {
+      params: new HttpParams({
+        fromString: `page=${page}`
+      })
+    }).pipe(
+      map((actions: any) => actions.map(action => action as Action))
+    );
   }
 }

--- a/src/app/services/cmc.service.ts
+++ b/src/app/services/cmc.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface CMCTicker {
+  data?: {
+    name: string;
+    symbol: string;
+    quotes: {
+      USD: {
+        price: number,
+        market_cap: number,
+        volume_24h: number
+      }
+    }
+  };
+  metadata?: any
+}
+
+@Injectable()
+export class CmcService {
+
+  constructor(
+    private http: HttpClient
+  ) { }
+
+  getEOSTicker(): Observable<CMCTicker> {
+    return this.http.get('https://api.coinmarketcap.com/v2/ticker/1765/');
+  }
+
+}


### PR DESCRIPTION
I updated "name" property from AccountComponent from type number to type string, I think name should be of type string. The services are using rxjs pipe, it will make upgrading to Angular v6 much easier later. Everything else is pretty much straight forward refactoring, I intentionally didn't change any component logic to limit the scope only refactoring out http reference in account component.

Please let me know if you want anything to be updated. I deployed my changes to https://eostrackerio.firebaseapp.com/. I tested a couple accounts, seems to be working. 